### PR TITLE
read current from IP5310 chip

### DIFF
--- a/x728-v2.1.sh
+++ b/x728-v2.1.sh
@@ -115,11 +115,19 @@ def readCapacity(bus):
      capacity = swapped/256
      return capacity
 
+def readCurrent(bus):
+
+     address = I2C_ADDR
+     read = bus.read_word_data(address, 20)
+     swapped_as_signed = struct.unpack("<h", struct.pack(">H", read))[0]
+     return swapped_as_signed
+
 bus = smbus.SMBus(1) # 0 = /dev/i2c-0 (port I2C0), 1 = /dev/i2c-1 (port I2C1)
 
 while True:
  print ("******************")
  print ("Voltage:%5.2fV" % readVoltage(bus))
+ print ("Current:%5dmA" % readCurrent(bus))
  print ("Battery:%5i%%" % readCapacity(bus))
 
  if readCapacity(bus) == 100:
@@ -137,10 +145,10 @@ while True:
         GPIO.output(GPIO_PORT, GPIO.LOW)
 
  time.sleep(2)
-' >> /home/pi/x728bat.py
+' > /home/pi/x728bat.py
 #sudo chmod +x /home/pi/x728bat.py
 
-#X728 AC Power loss / power adapter failture detection
+#X728 AC Power loss / power adapter failure detection
 #!/bin/bash
 echo '#!/usr/bin/env python
 import RPi.GPIO as GPIO


### PR DESCRIPTION
Hello,

I have added the possibility to see the current draw from the battery in mA.
Positive value = charging battery
Negative value = drawing energy from battery

Example 1: USB-C plugged in
******************
Voltage: 3.92V
Current: 1232mA
Battery:   16%
Battery Low

Example 2: unplugged, OS idle
******************
Voltage: 3.70V
Current: -156mA
Battery:   16%
Battery Low

Example 3: unplugged, CPU 100%
******************
Voltage: 3.66V
Current: -410mA
Battery:   16%
Battery Low

Hope this can help!